### PR TITLE
add a check if paginator before creating a dunglaspaginatoradapter

### DIFF
--- a/Eliberty/ApiBundle/JsonLd/Serializer/Normalizer.php
+++ b/Eliberty/ApiBundle/JsonLd/Serializer/Normalizer.php
@@ -82,7 +82,7 @@ class Normalizer
         $resource = new Item($object, $transformer);
         if ($object instanceof Paginator || $object instanceof PersistentCollection) {
             $resource = new Collection($object, $transformer);
-            if ($fractalManager->getSerializer() instanceof ArraySerializer) {
+            if ($fractalManager->getSerializer() instanceof ArraySerializer && $object instanceof Paginator) {
                 $resource->setPaginator(
                     new DunglasPaginatorAdapter($object, $resource)
                 );


### PR DESCRIPTION
lors d'une requete sur une collection d'embed vide, l'api crashait car on essayait de creer un dunglaspaginatoradapter depuis une collection 